### PR TITLE
Fix system dependencies with lcms2 and wxWidgets

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ else
   rt_dep = []
 endif
 
-wxwidgets_dep = dependency('wxWidgets')
+wxwidgets_dep = dependency('wxWidgets', required: get_option('build_viewer'))
 
 subdir('thirdparty')
 

--- a/src/bin/common/meson.build
+++ b/src/bin/common/meson.build
@@ -7,7 +7,8 @@ common_srcs = [ 'color.c']
 inc_dirs = include_directories('.','../../lib/openjp2')
 
 common_lib = static_library('common', common_srcs,
-                          include_directories : inc_dirs
+                          include_directories : inc_dirs,
+                          dependencies : [liblcms2_dep]
                           )
 common_dep = declare_dependency(link_with : common_lib,
           include_directories : inc_dirs)


### PR DESCRIPTION
Fix system dependencies such as lcms2 which can be used in the 3rd party folder.
wxWidgets should be checked only when visual tool options has been enabled.